### PR TITLE
Bugfixes

### DIFF
--- a/internal/characters/diluc/skill.go
+++ b/internal/characters/diluc/skill.go
@@ -71,7 +71,7 @@ func (c *char) Skill(p map[string]int) action.ActionInfo {
 	c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 2, false, combat.TargettableEnemy), hitmark, hitmark)
 
 	var orb float64 = 1
-	if c.Core.Rand.Float64() < 0.25 {
+	if c.Core.Rand.Float64() < 0.33 {
 		orb = 2
 	}
 	c.Core.QueueParticle("diluc", orb, attributes.Pyro, hitmark+c.Core.Flags.ParticleDelay)

--- a/internal/characters/diluc/skill.go
+++ b/internal/characters/diluc/skill.go
@@ -71,7 +71,7 @@ func (c *char) Skill(p map[string]int) action.ActionInfo {
 	c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 2, false, combat.TargettableEnemy), hitmark, hitmark)
 
 	var orb float64 = 1
-	if c.Core.Rand.Float64() < 0.33 {
+	if c.Core.Rand.Float64() < 0.25 {
 		orb = 2
 	}
 	c.Core.QueueParticle("diluc", orb, attributes.Pyro, hitmark+c.Core.Flags.ParticleDelay)

--- a/pkg/gcs/ast/parse.go
+++ b/pkg/gcs/ast/parse.go
@@ -14,6 +14,8 @@ type precedence int
 const (
 	_ precedence = iota
 	Lowest
+	LogicalOr
+	LogicalAnd // TODO: or make one for && and ||?
 	Equals
 	LessOrGreater
 	Sum
@@ -23,14 +25,14 @@ const (
 )
 
 var precedences = map[TokenType]precedence{
+	LogicOr:              LogicalOr,
+	LogicAnd:             LogicalAnd,
 	OpEqual:              Equals,
 	OpNotEqual:           Equals,
 	OpLessThan:           LessOrGreater,
 	OpGreaterThan:        LessOrGreater,
 	OpLessThanOrEqual:    LessOrGreater,
 	OpGreaterThanOrEqual: LessOrGreater,
-	LogicAnd:             LessOrGreater,
-	LogicOr:              LessOrGreater,
 	ItemPlus:             Sum,
 	ItemMinus:            Sum,
 	ItemForwardSlash:     Product,

--- a/pkg/gcs/ast/parse_test.go
+++ b/pkg/gcs/ast/parse_test.go
@@ -8,8 +8,7 @@ import (
 	"github.com/davecgh/go-spew/spew"
 )
 
-//this test won't pass because there's no active char....
-func testOrderPrecedence(t *testing.T) {
+func TestOrderPrecedence(t *testing.T) {
 	tests := []struct {
 		input    string
 		expected string
@@ -45,6 +44,14 @@ func testOrderPrecedence(t *testing.T) {
 		{
 			"(1+2)*3;",
 			"((1 + 2) * 3)",
+		},
+		{
+			"1==2 && 3!=4;",
+			"((1 == 2) && (3 != 4))",
+		},
+		{
+			"1 && 0 || 1+2 == 3;",
+			"((1 && 0) || ((1 + 2) == 3))",
 		},
 	}
 


### PR DESCRIPTION
- ~~Fix particles in Diluc skill: 1\~2 (2:1) => 1\~2 (3:1);~~
- Fix precedences for && and ||;