### PR TITLE
Phase 3.3: @gcsim/viewer metadata + result cards

### DIFF
--- a/ui-next/CLAUDE.md
+++ b/ui-next/CLAUDE.md
@@ -123,15 +123,17 @@ Dispatch these via the Agent tool for specialized work:
 
 ## Commit Discipline
 
-- **Commit after completing each spec step** (e.g., after finishing step 0.1, commit before starting 0.2)
-- **Commit after any self-contained unit of work** — a new config file, a package scaffold, a batch of related changes
+- **Commit often with small, standalone, tested changes** — each commit should build and pass tests on its own
+- **Commit after any self-contained unit of work** — a new config file, a component + its tests, a batch of related changes
 - **Don't bundle unrelated changes** into a single commit
 - **Commit messages** should be concise and describe the "what"
 - **When in doubt, commit sooner** — small commits are easier to review and revert
+- **Each commit must be independently valid**: it should typecheck, pass tests, and not break the build
 
 ## Git Workflow
 
-- Each parallel agent works on a branch: `phase-{N}/step-{X.Y}-{package-name}`
-- At phase gates, branches are merged sequentially (foundation packages first)
-- Worktree naming: `worktree-phase{N}-{package-name}`
-- Run `ui-next/tooling/cleanup-worktrees.sh` to remove stale worktrees
+- Each feature/package works on a branch: `phase-{N}/step-{X.Y}-{package-name}`
+- **Each feature must be PR'd into `web-rewrite`** before the task is considered finished
+- Small commits make PRs easier to review — each commit should be standalone
+- PR title should reference the spec step (e.g., "Phase 3.1: @gcsim/avatar package")
+- After PR is merged, the feature branch can be deleted

--- a/ui-next/PROGRESS.md
+++ b/ui-next/PROGRESS.md
@@ -231,7 +231,7 @@ Post-review fixes applied:
 |------|--------|-------------|
 | 2.1 | DONE | Design system tokens |
 | 2.2-2.4 | DONE | All shadcn primitives (installed via CLI) |
-| 2.5 | TODO | Storybook setup |
+| 2.5 | DONE | Storybook setup |
 
 ### Steps 2.1–2.4 — `@gcsim/primitives` (DONE)
 
@@ -242,7 +242,7 @@ Post-review fixes applied:
 - Custom Genshin element colors added: anemo, geo, electro, hydro, pyro, cryo, dendro
 - `cn()` utility from `src/lib/utils.ts` (clsx + tailwind-merge)
 - 11 shadcn components installed: Button, Card, Input, Tabs, Select, Badge, Dialog, DropdownMenu, Tooltip, ScrollArea, Skeleton
-- All components use unified `radix-ui` package and `@/lib/utils` path alias
+- All components use unified `radix-ui` package with relative imports (no `@/` path aliases — tsc doesn't rewrite them)
 - `tsconfig.json` has `baseUrl` + `paths` for `@/*` alias; `vitest.config.ts` mirrors with `resolve.alias`
 - `vitest.config.ts` includes `test-setup.ts` for `@testing-library/jest-dom/vitest` matchers
 - Barrel export in `src/index.ts` re-exports all components and `cn()`
@@ -251,6 +251,31 @@ Post-review fixes applied:
 - Dependencies: `radix-ui`, `class-variance-authority`, `clsx`, `tailwind-merge`, `shadcn`
 - DevDependencies: `tailwindcss@4.2.2`, `@tailwindcss/vite@4.2.2`, `tw-animate-css@1.3.4`, `lucide-react@0.577.0`
 
+### Step 2.5 — Storybook (DONE)
+
+- Created `apps/storybook/` with Storybook 10.3.1 + `@storybook/react-vite`
+- 30 stories covering all 11 primitives with autodocs
+- Tailwind integration via `@tailwindcss/postcss` (PostCSS, not Vite plugin — Storybook's Vite pipeline doesn't reliably pick up the Vite plugin)
+- `storybook.css` inlines theme.css content (can't `@import` across package boundaries for Tailwind processing)
+- `@source "../../../packages/primitives/src"` tells Tailwind to scan component source files for class names
+- Dev server: `pnpm --filter @gcsim/storybook dev` on port 6006
+
 ### Phase 2 Fixes
 
 - Enabled `tailwindDirectives: true` in `biome.json` CSS parser (Biome 2.x doesn't parse `@theme`, `@custom-variant`, `@apply` without it)
+- Replaced all `@/lib/utils` and `@/components/ui/*` imports in shadcn components with relative paths — TypeScript path aliases are NOT rewritten by `tsc --build`, causing runtime resolution failures
+- Removed embedded `.git` directory created by `shadcn init`
+
+### Phase 2 Learnings
+
+- **shadcn CLI creates a `.git` in the package** — must delete before committing
+- **`@/` path aliases don't work in library packages** — tsc emits them verbatim in `.js` output. Use relative imports instead. The `@/` alias in `tsconfig.json` + `vitest.config.ts` is kept only for test resolution.
+- **Storybook + Tailwind v4**: Use `@tailwindcss/postcss` with a `postcss.config.mjs`, not `@tailwindcss/vite`. The Vite plugin doesn't reliably activate in Storybook's internal Vite pipeline.
+- **`@source` paths are relative to the CSS file**, not the project root. Count `../` carefully.
+- **`@import "@gcsim/primitives/theme.css"` doesn't work for Tailwind processing** across package boundaries — inline the theme CSS in each consuming app's stylesheet instead.
+
+### Phase 2 Gate
+
+- All primitives: typecheck pass, 14 tests pass, build succeeds
+- Storybook: all 30 stories render with correct Tailwind styling
+- Total tests: 77 (Phase 1) + 14 (primitives) = 91 tests

--- a/ui-next/PROGRESS.md
+++ b/ui-next/PROGRESS.md
@@ -279,3 +279,32 @@ Post-review fixes applied:
 - All primitives: typecheck pass, 14 tests pass, build succeeds
 - Storybook: all 30 stories render with correct Tailwind styling
 - Total tests: 77 (Phase 1) + 14 (primitives) = 91 tests
+
+## Phase 3: Feature Packages
+
+| Step | Status | Description |
+|------|--------|-------------|
+| 3.3a-e | DONE | `@gcsim/viewer` metadata + result cards |
+| 3.4 | TODO | `@gcsim/viewer` charts |
+| 3.5 | TODO | `@gcsim/viewer` sample viewer |
+
+### Step 3.3 — `@gcsim/viewer` Metadata + Result Cards (DONE)
+
+- Created `packages/viewer/` with presentational components for simulation results
+- **Metadata sub-components** (3.3a): `Iterations`, `Mode`, `Commit`, `Warnings`
+  - Each takes a small slice of `Sim.SimResults` — pure presentational
+  - `Warnings` renders active warnings as destructive Badges
+- **TeamHeader** (3.3b): row of Cards showing character name, level, constellation, weapon
+  - Takes `Sim.Character[]`, renders one Card per character
+- **RollupCard** (3.3c): generic stat rollup card (mean, min, max, SD)
+  - Takes any `FloatStat`/`SummaryStat` and a label
+  - Formats numbers with `toLocaleString()`
+- **DPSCard** (3.3d): per-character DPS with proportional bar (canonical example)
+  - Takes character name, `FloatStat`, and `maxDPS` for proportional bar width
+- **TargetInfoCard** (3.3e): enemy info display (name, level, resistances)
+  - Takes `Sim.Enemy[]`, renders Card per target with resistance percentages
+- 32 tests passing (5 test files), typecheck clean, build succeeds
+- Dependencies: `@gcsim/primitives`, `@gcsim/types`, `@gcsim/i18n`
+- All components use `data-testid` attributes for testing
+- Uses relative imports (no `@/` aliases in library source)
+- Total tests: 91 (Phase 1+2) + 32 (viewer) = 123 tests

--- a/ui-next/packages/viewer/CLAUDE.md
+++ b/ui-next/packages/viewer/CLAUDE.md
@@ -1,0 +1,48 @@
+# @gcsim/viewer
+
+## Purpose
+
+Presentational components for displaying gcsim simulation results. Renders metadata, team composition, and statistical rollups from `Sim.SimResults` data. Components are pure (no data fetching) and composable -- apps wire them together with real data in Phase 4.
+
+## How to add a new component
+
+1. Create a directory under `src/` (kebab-case, e.g. `src/my-component/`)
+2. Add `my-component.tsx` with the component, typed with `Sim.*` props from `@gcsim/types`
+3. Add `my-component.test.tsx` with `@testing-library/react` tests
+4. Add `index.ts` barrel export
+5. Re-export from `src/index.ts`
+6. Run `npx biome check --write packages/viewer/`
+7. Run `turbo run typecheck test --filter=@gcsim/viewer`
+
+## Canonical example
+
+`src/result-cards/dps-card.tsx` -- per-character DPS card with proportional bar. Shows the pattern: typed props from `@gcsim/types`, primitives from `@gcsim/primitives`, data-testid attributes for testing, number formatting helper.
+
+## Public API
+
+All exports go through `src/index.ts`:
+
+- **Metadata:** `Iterations`, `Mode`, `Commit`, `Warnings` -- small sub-components for sim metadata
+- **TeamHeader** -- row of character cards showing name, level, constellation, weapon
+- **RollupCard** -- generic stat rollup (mean, min, max, SD) for any `FloatStat`/`SummaryStat`
+- **DPSCard** -- per-character DPS with proportional bar
+- **TargetInfoCard** -- enemy info display (name, level, resistances)
+
+Usage:
+```typescript
+import { DPSCard, RollupCard, TeamHeader, Iterations, Mode, Commit, Warnings } from "@gcsim/viewer";
+```
+
+## Dependencies
+
+- `@gcsim/primitives` -- Card, Badge, cn() utility
+- `@gcsim/types` -- `Sim.*` interfaces for all props
+- `@gcsim/i18n` -- internationalization (for future use)
+
+## Don'ts
+
+- Don't fetch data in components -- they are purely presentational
+- Don't import from other packages' `src/` -- only from their package index
+- Don't test visual appearance -- test content rendering and behavior
+- Don't use `@/` path aliases in source files -- use relative imports (aliases don't work in library builds)
+- Don't add app-specific logic -- apps compose these components in Phase 4

--- a/ui-next/packages/viewer/package.json
+++ b/ui-next/packages/viewer/package.json
@@ -1,0 +1,43 @@
+{
+  "name": "@gcsim/viewer",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    }
+  },
+  "scripts": {
+    "build": "tsc --build",
+    "test": "vitest run",
+    "typecheck": "tsc --noEmit",
+    "lint": "biome check"
+  },
+  "dependencies": {
+    "@gcsim/primitives": "workspace:*",
+    "@gcsim/types": "workspace:*",
+    "@gcsim/i18n": "workspace:*"
+  },
+  "peerDependencies": {
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0"
+  },
+  "devDependencies": {
+    "@tailwindcss/vite": "4.2.2",
+    "@testing-library/jest-dom": "6.6.3",
+    "@testing-library/react": "16.3.0",
+    "@types/react": "^19.0.0",
+    "@types/react-dom": "^19.0.0",
+    "jsdom": "29.0.0",
+    "react": "19.2.4",
+    "react-dom": "19.2.4",
+    "tailwindcss": "4.2.2",
+    "typescript": "5.9.3",
+    "vite": "8.0.1",
+    "vitest": "4.1.0"
+  }
+}

--- a/ui-next/packages/viewer/src/index.ts
+++ b/ui-next/packages/viewer/src/index.ts
@@ -1,1 +1,10 @@
 // @gcsim/viewer public API
+
+export type {
+  CommitProps,
+  IterationsProps,
+  ModeProps,
+  WarningsProps,
+} from "./metadata/index.js";
+// Metadata
+export { Commit, Iterations, Mode, Warnings } from "./metadata/index.js";

--- a/ui-next/packages/viewer/src/index.ts
+++ b/ui-next/packages/viewer/src/index.ts
@@ -8,9 +8,9 @@ export type {
 } from "./metadata/index.js";
 // Metadata
 export { Commit, Iterations, Mode, Warnings } from "./metadata/index.js";
-export type { DPSCardProps, RollupCardProps } from "./result-cards/index.js";
+export type { DPSCardProps, RollupCardProps, TargetInfoCardProps } from "./result-cards/index.js";
 // Result Cards
-export { DPSCard, RollupCard } from "./result-cards/index.js";
+export { DPSCard, RollupCard, TargetInfoCard } from "./result-cards/index.js";
 export type { TeamHeaderProps } from "./team-header/index.js";
 // Team Header
 export { TeamHeader } from "./team-header/index.js";

--- a/ui-next/packages/viewer/src/index.ts
+++ b/ui-next/packages/viewer/src/index.ts
@@ -8,9 +8,9 @@ export type {
 } from "./metadata/index.js";
 // Metadata
 export { Commit, Iterations, Mode, Warnings } from "./metadata/index.js";
-export type { RollupCardProps } from "./result-cards/index.js";
+export type { DPSCardProps, RollupCardProps } from "./result-cards/index.js";
 // Result Cards
-export { RollupCard } from "./result-cards/index.js";
+export { DPSCard, RollupCard } from "./result-cards/index.js";
 export type { TeamHeaderProps } from "./team-header/index.js";
 // Team Header
 export { TeamHeader } from "./team-header/index.js";

--- a/ui-next/packages/viewer/src/index.ts
+++ b/ui-next/packages/viewer/src/index.ts
@@ -8,7 +8,9 @@ export type {
 } from "./metadata/index.js";
 // Metadata
 export { Commit, Iterations, Mode, Warnings } from "./metadata/index.js";
-
+export type { RollupCardProps } from "./result-cards/index.js";
+// Result Cards
+export { RollupCard } from "./result-cards/index.js";
+export type { TeamHeaderProps } from "./team-header/index.js";
 // Team Header
 export { TeamHeader } from "./team-header/index.js";
-export type { TeamHeaderProps } from "./team-header/index.js";

--- a/ui-next/packages/viewer/src/index.ts
+++ b/ui-next/packages/viewer/src/index.ts
@@ -1,0 +1,1 @@
+// @gcsim/viewer public API

--- a/ui-next/packages/viewer/src/index.ts
+++ b/ui-next/packages/viewer/src/index.ts
@@ -8,3 +8,7 @@ export type {
 } from "./metadata/index.js";
 // Metadata
 export { Commit, Iterations, Mode, Warnings } from "./metadata/index.js";
+
+// Team Header
+export { TeamHeader } from "./team-header/index.js";
+export type { TeamHeaderProps } from "./team-header/index.js";

--- a/ui-next/packages/viewer/src/metadata/index.ts
+++ b/ui-next/packages/viewer/src/metadata/index.ts
@@ -1,0 +1,7 @@
+export type {
+  CommitProps,
+  IterationsProps,
+  ModeProps,
+  WarningsProps,
+} from "./metadata.js";
+export { Commit, Iterations, Mode, Warnings } from "./metadata.js";

--- a/ui-next/packages/viewer/src/metadata/metadata.test.tsx
+++ b/ui-next/packages/viewer/src/metadata/metadata.test.tsx
@@ -1,0 +1,85 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { Commit, Iterations, Mode, Warnings } from "./metadata.js";
+
+describe("Iterations", () => {
+  it("renders iteration count", () => {
+    render(<Iterations iterations={1000} />);
+    expect(screen.getByTestId("iterations")).toHaveTextContent("1,000 iterations");
+  });
+
+  it("renders nothing when iterations is undefined", () => {
+    const { container } = render(<Iterations />);
+    expect(container.firstChild).toBeNull();
+  });
+});
+
+describe("Mode", () => {
+  it("renders SL for mode 0", () => {
+    render(<Mode mode={0} />);
+    expect(screen.getByTestId("mode")).toHaveTextContent("SL");
+  });
+
+  it("renders TTK for mode 1", () => {
+    render(<Mode mode={1} />);
+    expect(screen.getByTestId("mode")).toHaveTextContent("TTK");
+  });
+
+  it("renders nothing when mode is undefined", () => {
+    const { container } = render(<Mode />);
+    expect(container.firstChild).toBeNull();
+  });
+});
+
+describe("Commit", () => {
+  it("renders sim version and build date", () => {
+    render(<Commit simVersion="2.5.0" buildDate="2026-03-19" />);
+    expect(screen.getByTestId("sim-version")).toHaveTextContent("2.5.0");
+    expect(screen.getByTestId("build-date")).toHaveTextContent("2026-03-19");
+  });
+
+  it("renders only sim version when build date is missing", () => {
+    render(<Commit simVersion="2.5.0" />);
+    expect(screen.getByTestId("sim-version")).toHaveTextContent("2.5.0");
+    expect(screen.queryByTestId("build-date")).toBeNull();
+  });
+
+  it("renders nothing when both are missing", () => {
+    const { container } = render(<Commit />);
+    expect(container.firstChild).toBeNull();
+  });
+});
+
+describe("Warnings", () => {
+  it("renders active warnings as badges", () => {
+    render(
+      <Warnings
+        warnings={{
+          target_overlap: true,
+          insufficient_energy: true,
+          swap_cd: false,
+        }}
+      />,
+    );
+    expect(screen.getByText("Target Overlap")).toBeInTheDocument();
+    expect(screen.getByText("Insufficient Energy")).toBeInTheDocument();
+    expect(screen.queryByText("Swap CD")).not.toBeInTheDocument();
+  });
+
+  it("renders nothing when no warnings are active", () => {
+    const { container } = render(
+      <Warnings
+        warnings={{
+          target_overlap: false,
+          insufficient_energy: false,
+        }}
+      />,
+    );
+    expect(container.querySelector("[data-testid='warnings']")).toBeNull();
+  });
+
+  it("renders nothing when warnings is undefined", () => {
+    const { container } = render(<Warnings />);
+    expect(container.firstChild).toBeNull();
+  });
+});

--- a/ui-next/packages/viewer/src/metadata/metadata.tsx
+++ b/ui-next/packages/viewer/src/metadata/metadata.tsx
@@ -1,0 +1,68 @@
+import { Badge } from "@gcsim/primitives";
+import type { Sim } from "@gcsim/types";
+
+export interface IterationsProps {
+  iterations?: number;
+}
+
+export function Iterations({ iterations }: IterationsProps) {
+  if (iterations == null) return null;
+  return <span data-testid="iterations">{iterations.toLocaleString()} iterations</span>;
+}
+
+export interface ModeProps {
+  mode?: number;
+}
+
+export function Mode({ mode }: ModeProps) {
+  if (mode == null) return null;
+  const label = mode === 0 ? "SL" : "TTK";
+  return <span data-testid="mode">{label}</span>;
+}
+
+export interface CommitProps {
+  simVersion?: string;
+  buildDate?: string;
+}
+
+export function Commit({ simVersion, buildDate }: CommitProps) {
+  if (!simVersion && !buildDate) return null;
+  return (
+    <span data-testid="commit">
+      {simVersion && <span data-testid="sim-version">{simVersion}</span>}
+      {simVersion && buildDate && " — "}
+      {buildDate && <span data-testid="build-date">{buildDate}</span>}
+    </span>
+  );
+}
+
+export interface WarningsProps {
+  warnings?: Sim.Warnings;
+}
+
+const warningLabels: Record<string, string> = {
+  target_overlap: "Target Overlap",
+  insufficient_energy: "Insufficient Energy",
+  insufficient_stamina: "Insufficient Stamina",
+  swap_cd: "Swap CD",
+  skill_cd: "Skill CD",
+  dash_cd: "Dash CD",
+  burst_cd: "Burst CD",
+};
+
+export function Warnings({ warnings }: WarningsProps) {
+  if (!warnings) return null;
+
+  const active = Object.entries(warnings).filter(([, v]) => v === true);
+  if (active.length === 0) return null;
+
+  return (
+    <div data-testid="warnings" className="flex flex-wrap gap-1">
+      {active.map(([key]) => (
+        <Badge key={key} variant="destructive">
+          {warningLabels[key] ?? key}
+        </Badge>
+      ))}
+    </div>
+  );
+}

--- a/ui-next/packages/viewer/src/result-cards/dps-card.test.tsx
+++ b/ui-next/packages/viewer/src/result-cards/dps-card.test.tsx
@@ -1,0 +1,46 @@
+import type { Sim } from "@gcsim/types";
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { DPSCard } from "./dps-card.js";
+
+const mockDPS: Sim.FloatStat = {
+  min: 20000,
+  max: 45000,
+  mean: 35100,
+  sd: 3200,
+};
+
+describe("DPSCard", () => {
+  it("renders character name", () => {
+    render(<DPSCard characterName="hutao" stat={mockDPS} maxDPS={35100} />);
+    expect(screen.getByTestId("dps-char-name")).toHaveTextContent("hutao");
+  });
+
+  it("renders formatted DPS value", () => {
+    render(<DPSCard characterName="hutao" stat={mockDPS} maxDPS={35100} />);
+    expect(screen.getByTestId("dps-value")).toHaveTextContent("35,100");
+  });
+
+  it("renders proportional bar width", () => {
+    render(<DPSCard characterName="hutao" stat={mockDPS} maxDPS={70200} />);
+    const bar = screen.getByTestId("dps-bar");
+    expect(bar).toHaveStyle({ width: "50%" });
+  });
+
+  it("renders 100% bar when DPS equals max", () => {
+    render(<DPSCard characterName="hutao" stat={mockDPS} maxDPS={35100} />);
+    const bar = screen.getByTestId("dps-bar");
+    expect(bar).toHaveStyle({ width: "100%" });
+  });
+
+  it("renders dash when stat is undefined", () => {
+    render(<DPSCard characterName="hutao" />);
+    expect(screen.getByTestId("dps-value")).toHaveTextContent("—");
+  });
+
+  it("renders 0% bar when maxDPS is undefined", () => {
+    render(<DPSCard characterName="hutao" stat={mockDPS} />);
+    const bar = screen.getByTestId("dps-bar");
+    expect(bar).toHaveStyle({ width: "0%" });
+  });
+});

--- a/ui-next/packages/viewer/src/result-cards/dps-card.tsx
+++ b/ui-next/packages/viewer/src/result-cards/dps-card.tsx
@@ -1,0 +1,42 @@
+import { Card, CardContent, cn } from "@gcsim/primitives";
+import type { Sim } from "@gcsim/types";
+
+export interface DPSCardProps {
+  characterName: string;
+  stat?: Sim.FloatStat;
+  /** Maximum DPS across all characters, used to calculate proportional bar width */
+  maxDPS?: number;
+  className?: string;
+}
+
+function formatDPS(value: number | undefined): string {
+  if (value == null) return "—";
+  return value.toLocaleString(undefined, { maximumFractionDigits: 0 });
+}
+
+export function DPSCard({ characterName, stat, maxDPS, className }: DPSCardProps) {
+  const mean = stat?.mean;
+  const barWidth = mean != null && maxDPS != null && maxDPS > 0 ? (mean / maxDPS) * 100 : 0;
+
+  return (
+    <Card className={cn("min-w-[200px]", className)} data-testid="dps-card">
+      <CardContent className="p-3">
+        <div className="flex items-center justify-between">
+          <span className="font-medium capitalize" data-testid="dps-char-name">
+            {characterName}
+          </span>
+          <span className="font-bold tabular-nums" data-testid="dps-value">
+            {formatDPS(mean)}
+          </span>
+        </div>
+        <div className="bg-muted mt-2 h-2 w-full overflow-hidden rounded-full">
+          <div
+            className="bg-primary h-full rounded-full transition-all"
+            style={{ width: `${barWidth}%` }}
+            data-testid="dps-bar"
+          />
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/ui-next/packages/viewer/src/result-cards/index.ts
+++ b/ui-next/packages/viewer/src/result-cards/index.ts
@@ -2,3 +2,5 @@ export type { DPSCardProps } from "./dps-card.js";
 export { DPSCard } from "./dps-card.js";
 export type { RollupCardProps } from "./rollup-card.js";
 export { RollupCard } from "./rollup-card.js";
+export type { TargetInfoCardProps } from "./target-info-card.js";
+export { TargetInfoCard } from "./target-info-card.js";

--- a/ui-next/packages/viewer/src/result-cards/index.ts
+++ b/ui-next/packages/viewer/src/result-cards/index.ts
@@ -1,2 +1,4 @@
+export type { DPSCardProps } from "./dps-card.js";
+export { DPSCard } from "./dps-card.js";
 export type { RollupCardProps } from "./rollup-card.js";
 export { RollupCard } from "./rollup-card.js";

--- a/ui-next/packages/viewer/src/result-cards/index.ts
+++ b/ui-next/packages/viewer/src/result-cards/index.ts
@@ -1,0 +1,2 @@
+export type { RollupCardProps } from "./rollup-card.js";
+export { RollupCard } from "./rollup-card.js";

--- a/ui-next/packages/viewer/src/result-cards/rollup-card.test.tsx
+++ b/ui-next/packages/viewer/src/result-cards/rollup-card.test.tsx
@@ -1,0 +1,36 @@
+import type { Sim } from "@gcsim/types";
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { RollupCard } from "./rollup-card.js";
+
+const mockStat: Sim.SummaryStat = {
+  min: 35000,
+  max: 65000,
+  mean: 50250.5,
+  sd: 4200.3,
+};
+
+describe("RollupCard", () => {
+  it("renders the label", () => {
+    render(<RollupCard label="DPS" stat={mockStat} />);
+    expect(screen.getByText("DPS")).toBeInTheDocument();
+  });
+
+  it("renders mean value", () => {
+    render(<RollupCard label="DPS" stat={mockStat} />);
+    expect(screen.getByTestId("rollup-mean")).toHaveTextContent("50,250.5");
+  });
+
+  it("renders min, max, and sd", () => {
+    render(<RollupCard label="DPS" stat={mockStat} />);
+    expect(screen.getByTestId("rollup-min")).toHaveTextContent("Min: 35,000");
+    expect(screen.getByTestId("rollup-max")).toHaveTextContent("Max: 65,000");
+    expect(screen.getByTestId("rollup-sd")).toHaveTextContent("SD: 4,200.3");
+  });
+
+  it("renders dashes when stat is undefined", () => {
+    render(<RollupCard label="DPS" />);
+    expect(screen.getByTestId("rollup-mean")).toHaveTextContent("—");
+    expect(screen.getByTestId("rollup-min")).toHaveTextContent("Min: —");
+  });
+});

--- a/ui-next/packages/viewer/src/result-cards/rollup-card.tsx
+++ b/ui-next/packages/viewer/src/result-cards/rollup-card.tsx
@@ -1,0 +1,35 @@
+import { Card, CardContent, CardHeader, CardTitle, cn } from "@gcsim/primitives";
+import type { Sim } from "@gcsim/types";
+
+export interface RollupCardProps {
+  label: string;
+  stat?: Sim.FloatStat | Sim.SummaryStat;
+  className?: string;
+}
+
+function formatNumber(value: number | undefined): string {
+  if (value == null) return "—";
+  return value.toLocaleString(undefined, { maximumFractionDigits: 2 });
+}
+
+export function RollupCard({ label, stat, className }: RollupCardProps) {
+  return (
+    <Card className={cn("min-w-[180px]", className)} data-testid="rollup-card">
+      <CardHeader className="pb-2">
+        <CardTitle className="text-sm font-medium">{label}</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <div className="text-2xl font-bold" data-testid="rollup-mean">
+          {formatNumber(stat?.mean)}
+        </div>
+        <div className="text-muted-foreground mt-1 text-xs">
+          <span data-testid="rollup-min">Min: {formatNumber(stat?.min)}</span>
+          {" / "}
+          <span data-testid="rollup-max">Max: {formatNumber(stat?.max)}</span>
+          {" / "}
+          <span data-testid="rollup-sd">SD: {formatNumber(stat?.sd)}</span>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/ui-next/packages/viewer/src/result-cards/target-info-card.test.tsx
+++ b/ui-next/packages/viewer/src/result-cards/target-info-card.test.tsx
@@ -1,0 +1,65 @@
+import type { Sim } from "@gcsim/types";
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { TargetInfoCard } from "./target-info-card.js";
+
+const mockEnemies: Sim.Enemy[] = [
+  {
+    name: "target-1",
+    level: 100,
+    hp: 10000000,
+    resist: {
+      pyro: 0.1,
+      hydro: 0.1,
+      cryo: 0.1,
+    },
+    position: { x: 0, y: 0, r: 1 },
+  },
+];
+
+describe("TargetInfoCard", () => {
+  it("renders target name", () => {
+    render(<TargetInfoCard enemies={mockEnemies} />);
+    expect(screen.getByTestId("target-name")).toHaveTextContent("target-1");
+  });
+
+  it("renders target level", () => {
+    render(<TargetInfoCard enemies={mockEnemies} />);
+    expect(screen.getByTestId("target-level")).toHaveTextContent("Level 100");
+  });
+
+  it("renders resistances", () => {
+    render(<TargetInfoCard enemies={mockEnemies} />);
+    const resists = screen.getByTestId("target-resists");
+    expect(resists).toHaveTextContent("pyro: 10%");
+    expect(resists).toHaveTextContent("hydro: 10%");
+    expect(resists).toHaveTextContent("cryo: 10%");
+  });
+
+  it("uses fallback name when name is not provided", () => {
+    render(<TargetInfoCard enemies={[{ level: 90, resist: {} }]} />);
+    expect(screen.getByTestId("target-name")).toHaveTextContent("Target 1");
+  });
+
+  it("renders nothing when enemies is undefined", () => {
+    const { container } = render(<TargetInfoCard />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("renders nothing when enemies is empty", () => {
+    const { container } = render(<TargetInfoCard enemies={[]} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("renders multiple targets", () => {
+    const twoEnemies: Sim.Enemy[] = [
+      { name: "boss-1", level: 100, resist: {} },
+      { name: "boss-2", level: 95, resist: {} },
+    ];
+    render(<TargetInfoCard enemies={twoEnemies} />);
+    const names = screen.getAllByTestId("target-name");
+    expect(names).toHaveLength(2);
+    expect(names[0]).toHaveTextContent("boss-1");
+    expect(names[1]).toHaveTextContent("boss-2");
+  });
+});

--- a/ui-next/packages/viewer/src/result-cards/target-info-card.tsx
+++ b/ui-next/packages/viewer/src/result-cards/target-info-card.tsx
@@ -1,0 +1,51 @@
+import { Card, CardContent, CardHeader, CardTitle, cn } from "@gcsim/primitives";
+import type { Sim } from "@gcsim/types";
+
+export interface TargetInfoCardProps {
+  enemies?: Sim.Enemy[];
+  className?: string;
+}
+
+function formatResist(value: number): string {
+  return `${(value * 100).toFixed(0)}%`;
+}
+
+export function TargetInfoCard({ enemies, className }: TargetInfoCardProps) {
+  if (!enemies || enemies.length === 0) return null;
+
+  return (
+    <div data-testid="target-info" className={cn("flex flex-wrap gap-2", className)}>
+      {enemies.map((enemy, i) => {
+        const label = enemy.name ?? `Target ${i + 1}`;
+        return (
+          <Card key={label} className="min-w-[180px] flex-1">
+            <CardHeader className="pb-2">
+              <CardTitle className="text-sm font-medium" data-testid="target-name">
+                {label}
+              </CardTitle>
+            </CardHeader>
+            <CardContent>
+              {enemy.level != null && (
+                <div className="text-muted-foreground text-sm" data-testid="target-level">
+                  Level {enemy.level}
+                </div>
+              )}
+              {enemy.resist && Object.keys(enemy.resist).length > 0 && (
+                <div
+                  className="mt-1 flex flex-wrap gap-x-3 gap-y-0.5 text-xs"
+                  data-testid="target-resists"
+                >
+                  {Object.entries(enemy.resist).map(([element, value]) => (
+                    <span key={element} className="capitalize">
+                      {element}: {formatResist(value)}
+                    </span>
+                  ))}
+                </div>
+              )}
+            </CardContent>
+          </Card>
+        );
+      })}
+    </div>
+  );
+}

--- a/ui-next/packages/viewer/src/team-header/index.ts
+++ b/ui-next/packages/viewer/src/team-header/index.ts
@@ -1,0 +1,2 @@
+export type { TeamHeaderProps } from "./team-header.js";
+export { TeamHeader } from "./team-header.js";

--- a/ui-next/packages/viewer/src/team-header/team-header.test.tsx
+++ b/ui-next/packages/viewer/src/team-header/team-header.test.tsx
@@ -1,0 +1,67 @@
+import type { Sim } from "@gcsim/types";
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { TeamHeader } from "./team-header.js";
+
+const mockCharacters: Sim.Character[] = [
+  {
+    name: "hutao",
+    level: 90,
+    max_level: 90,
+    element: "pyro",
+    cons: 1,
+    weapon: { name: "staffofhoma", refine: 1, level: 90, max_level: 90 },
+    talents: { attack: 10, skill: 10, burst: 10 },
+    stats: [],
+    snapshot: [],
+    sets: { crimsonwitchofflames: 4 },
+  },
+  {
+    name: "xingqiu",
+    level: 90,
+    max_level: 90,
+    element: "hydro",
+    cons: 6,
+    weapon: { name: "sacrificialsword", refine: 5, level: 90, max_level: 90 },
+    talents: { attack: 1, skill: 10, burst: 13 },
+    stats: [],
+    snapshot: [],
+    sets: { emblemofseveredfate: 4 },
+  },
+];
+
+describe("TeamHeader", () => {
+  it("renders a card for each character", () => {
+    render(<TeamHeader characters={mockCharacters} />);
+    const names = screen.getAllByTestId("char-name");
+    expect(names).toHaveLength(2);
+    expect(names[0]).toHaveTextContent("hutao");
+    expect(names[1]).toHaveTextContent("xingqiu");
+  });
+
+  it("shows level, constellation, and weapon", () => {
+    render(<TeamHeader characters={mockCharacters} />);
+    const levels = screen.getAllByTestId("char-level");
+    expect(levels[0]).toHaveTextContent("Lv. 90/90");
+
+    const cons = screen.getAllByTestId("char-cons");
+    expect(cons[0]).toHaveTextContent("C1");
+    expect(cons[1]).toHaveTextContent("C6");
+
+    const weapons = screen.getAllByTestId("char-weapon");
+    expect(weapons[0]).toHaveTextContent("staffofhoma");
+
+    const refines = screen.getAllByTestId("char-weapon-refine");
+    expect(refines[0]).toHaveTextContent("1");
+  });
+
+  it("renders nothing when characters is undefined", () => {
+    const { container } = render(<TeamHeader />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("renders nothing when characters is empty", () => {
+    const { container } = render(<TeamHeader characters={[]} />);
+    expect(container.firstChild).toBeNull();
+  });
+});

--- a/ui-next/packages/viewer/src/team-header/team-header.tsx
+++ b/ui-next/packages/viewer/src/team-header/team-header.tsx
@@ -1,0 +1,39 @@
+import { Card, CardContent, cn } from "@gcsim/primitives";
+import type { Sim } from "@gcsim/types";
+
+export interface TeamHeaderProps {
+  characters?: Sim.Character[];
+  className?: string;
+}
+
+export function TeamHeader({ characters, className }: TeamHeaderProps) {
+  if (!characters || characters.length === 0) return null;
+
+  return (
+    <div data-testid="team-header" className={cn("flex flex-wrap gap-2", className)}>
+      {characters.map((char) => (
+        <Card key={char.name} className="min-w-[140px] flex-1">
+          <CardContent className="p-3">
+            <div className="font-semibold capitalize" data-testid="char-name">
+              {char.name}
+            </div>
+            <div className="text-muted-foreground text-sm">
+              <span data-testid="char-level">
+                Lv. {char.level}/{char.max_level}
+              </span>
+              {" — "}
+              <span data-testid="char-cons">C{char.cons}</span>
+            </div>
+            <div className="text-muted-foreground text-sm">
+              <span data-testid="char-weapon" className="capitalize">
+                {char.weapon.name}
+              </span>
+              {" R"}
+              <span data-testid="char-weapon-refine">{char.weapon.refine}</span>
+            </div>
+          </CardContent>
+        </Card>
+      ))}
+    </div>
+  );
+}

--- a/ui-next/packages/viewer/src/test-setup.ts
+++ b/ui-next/packages/viewer/src/test-setup.ts
@@ -1,0 +1,1 @@
+import "@testing-library/jest-dom/vitest";

--- a/ui-next/packages/viewer/tsconfig.json
+++ b/ui-next/packages/viewer/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tooling/typescript/base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"]
+}

--- a/ui-next/packages/viewer/vitest.config.ts
+++ b/ui-next/packages/viewer/vitest.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig, mergeConfig } from "vitest/config";
+import baseConfig from "../../tooling/vitest/base.ts";
+
+export default mergeConfig(
+  baseConfig,
+  defineConfig({
+    test: {
+      setupFiles: ["./src/test-setup.ts"],
+    },
+  }),
+);


### PR DESCRIPTION
## Summary
- Scaffold `@gcsim/viewer` package with TDD workflow
- Add metadata component (Iterations, Mode, Commit, Warnings)
- Add team-header, rollup-card, dps-card (canonical example), target-info-card
- 32 tests passing, typecheck clean, build succeeds

## Test plan
- [x] `turbo run typecheck --filter=@gcsim/viewer` passes
- [x] `turbo run test --filter=@gcsim/viewer` passes (32 tests)
- [x] `turbo run build --filter=@gcsim/viewer` succeeds
- [x] Biome check clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)