### PR TITLE
Phase 3.1: @gcsim/avatar package

### DIFF
--- a/ui-next/packages/avatar/CLAUDE.md
+++ b/ui-next/packages/avatar/CLAUDE.md
@@ -1,0 +1,61 @@
+# @gcsim/avatar
+
+## Purpose
+
+Character display components for the gcsim web UI. Renders character portraits, detailed character cards, and team compositions.
+
+## How to Add a New Component
+
+Follow the `/new-component` pattern:
+
+1. Create `src/<component-name>/` directory
+2. Add `<component-name>.tsx` with the component
+3. Add `<component-name>.test.tsx` with tests
+4. Add `index.ts` with named exports
+5. Re-export from `src/index.ts`
+6. Run `npx biome check --write packages/avatar/`
+
+Canonical example: `src/portrait/`
+
+## Public API
+
+All exports go through `src/index.ts`:
+
+- **`Portrait`** — Circular avatar placeholder with character initial and element badge
+- **`AvatarCard`** — Full character card showing name, level, constellation, weapon, and talents
+- **`TeamDisplay`** — Horizontal row of Portrait components for 1-4 characters
+
+Usage:
+
+```typescript
+import { Portrait, AvatarCard, TeamDisplay } from "@gcsim/avatar";
+import type { Sim } from "@gcsim/types";
+
+// Simple portrait
+<Portrait characterKey="hutao" element="pyro" size="lg" />
+
+// Full character card
+<AvatarCard character={character} />
+
+// Team row
+<TeamDisplay characters={team} />
+```
+
+## Dependencies
+
+- `@gcsim/primitives` — Card components, `cn()` utility, theme tokens
+- `@gcsim/types` — `Sim.Character`, `Sim.Weapon`, `Sim.Talent` interfaces
+- `@gcsim/data` — Static game data (not yet used, available for future components)
+
+## Testing
+
+Tests use shared fixtures from `tooling/test-fixtures/`. Test files are excluded from `tsconfig.json` (via `exclude`) to avoid rootDir issues with cross-package fixture imports. Vitest handles type resolution independently.
+
+Run tests: `pnpm test` or `turbo run test --filter=@gcsim/avatar`
+
+## Don'ts
+
+- Don't import from other packages' `src/` — only from their package index
+- Don't hardcode colors — use element theme tokens (`text-pyro`, `border-anemo/40`, etc.)
+- Don't add app-specific logic here — this package is for reusable character display components
+- Don't add actual game images — those come from the API/CDN at runtime

--- a/ui-next/packages/avatar/package.json
+++ b/ui-next/packages/avatar/package.json
@@ -1,0 +1,40 @@
+{
+  "name": "@gcsim/avatar",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    }
+  },
+  "scripts": {
+    "build": "tsc --build",
+    "test": "vitest run",
+    "typecheck": "tsc --noEmit",
+    "lint": "biome check"
+  },
+  "dependencies": {
+    "@gcsim/primitives": "workspace:*",
+    "@gcsim/types": "workspace:*",
+    "@gcsim/data": "workspace:*"
+  },
+  "peerDependencies": {
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0"
+  },
+  "devDependencies": {
+    "@testing-library/jest-dom": "6.6.3",
+    "@testing-library/react": "16.3.0",
+    "@types/react": "^19.0.0",
+    "@types/react-dom": "^19.0.0",
+    "jsdom": "29.0.0",
+    "react": "19.2.4",
+    "react-dom": "19.2.4",
+    "typescript": "5.9.3",
+    "vitest": "4.1.0"
+  }
+}

--- a/ui-next/packages/avatar/src/avatar-card/avatar-card.test.tsx
+++ b/ui-next/packages/avatar/src/avatar-card/avatar-card.test.tsx
@@ -1,0 +1,64 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { mockHutao, mockXingqiu } from "../../../../tooling/test-fixtures/index.js";
+import { AvatarCard } from "./avatar-card.js";
+
+describe("AvatarCard", () => {
+  it("renders character name", () => {
+    render(<AvatarCard character={mockHutao} />);
+    expect(screen.getByTestId("avatar-card-name")).toHaveTextContent("hutao");
+  });
+
+  it("renders level and max level", () => {
+    render(<AvatarCard character={mockHutao} />);
+    expect(screen.getByTestId("avatar-card-level")).toHaveTextContent("Lv. 90/90");
+  });
+
+  it("renders constellation count", () => {
+    render(<AvatarCard character={mockHutao} />);
+    expect(screen.getByTestId("avatar-card-cons")).toHaveTextContent("C1");
+  });
+
+  it("renders weapon info", () => {
+    render(<AvatarCard character={mockHutao} />);
+    expect(screen.getByTestId("avatar-card-weapon")).toHaveTextContent("staffofhoma R1");
+  });
+
+  it("renders talent levels", () => {
+    render(<AvatarCard character={mockHutao} />);
+    expect(screen.getByTestId("avatar-card-talents")).toHaveTextContent("10/10/10");
+  });
+
+  it("renders different character data correctly", () => {
+    render(<AvatarCard character={mockXingqiu} />);
+    expect(screen.getByTestId("avatar-card-name")).toHaveTextContent("xingqiu");
+    expect(screen.getByTestId("avatar-card-cons")).toHaveTextContent("C6");
+    expect(screen.getByTestId("avatar-card-weapon")).toHaveTextContent("sacrificialsword R5");
+    expect(screen.getByTestId("avatar-card-talents")).toHaveTextContent("1/10/13");
+  });
+
+  it("includes portrait with correct element", () => {
+    render(<AvatarCard character={mockHutao} />);
+    const element = screen.getByTestId("portrait-element");
+    expect(element).toHaveTextContent("pyro");
+  });
+
+  it("handles partial data gracefully", () => {
+    const partial = {
+      name: "unknown",
+      level: 1,
+      max_level: 20,
+      element: "",
+      cons: 0,
+      weapon: { name: "dullblade", refine: 1, level: 1, max_level: 20 },
+      talents: { attack: 1, skill: 1, burst: 1 },
+      stats: [],
+      snapshot: [],
+      sets: {},
+    };
+    render(<AvatarCard character={partial} />);
+    expect(screen.getByTestId("avatar-card-name")).toHaveTextContent("unknown");
+    expect(screen.getByTestId("avatar-card-level")).toHaveTextContent("Lv. 1/20");
+    expect(screen.getByTestId("avatar-card-cons")).toHaveTextContent("C0");
+  });
+});

--- a/ui-next/packages/avatar/src/avatar-card/avatar-card.tsx
+++ b/ui-next/packages/avatar/src/avatar-card/avatar-card.tsx
@@ -1,0 +1,54 @@
+import { Card, CardContent, CardHeader, CardTitle, cn } from "@gcsim/primitives";
+import type { Sim } from "@gcsim/types";
+import { Portrait } from "../portrait/index.js";
+
+export interface AvatarCardProps {
+  character: Sim.Character;
+  className?: string;
+}
+
+function formatLevel(level: number, maxLevel: number): string {
+  return `${level}/${maxLevel}`;
+}
+
+function formatWeapon(weapon: Sim.Weapon): string {
+  return `${weapon.name} R${weapon.refine}`;
+}
+
+function formatTalents(talents: Sim.Talent): string {
+  return `${talents.attack}/${talents.skill}/${talents.burst}`;
+}
+
+export function AvatarCard({ character, className }: AvatarCardProps) {
+  return (
+    <Card data-testid="avatar-card" className={cn("w-fit", className)}>
+      <CardHeader className="flex-row items-center gap-3">
+        <Portrait characterKey={character.name} element={character.element} size="lg" />
+        <div>
+          <CardTitle data-testid="avatar-card-name">{character.name}</CardTitle>
+          <p data-testid="avatar-card-level" className="text-xs text-muted-foreground">
+            Lv. {formatLevel(character.level, character.max_level)}
+          </p>
+        </div>
+      </CardHeader>
+      <CardContent className="space-y-1 text-xs">
+        <p data-testid="avatar-card-cons">
+          <span className="text-muted-foreground">Constellation: </span>
+          <span className="font-medium">C{character.cons}</span>
+        </p>
+        {character.weapon ? (
+          <p data-testid="avatar-card-weapon">
+            <span className="text-muted-foreground">Weapon: </span>
+            <span className="font-medium">{formatWeapon(character.weapon)}</span>
+          </p>
+        ) : null}
+        {character.talents ? (
+          <p data-testid="avatar-card-talents">
+            <span className="text-muted-foreground">Talents: </span>
+            <span className="font-medium">{formatTalents(character.talents)}</span>
+          </p>
+        ) : null}
+      </CardContent>
+    </Card>
+  );
+}

--- a/ui-next/packages/avatar/src/avatar-card/index.ts
+++ b/ui-next/packages/avatar/src/avatar-card/index.ts
@@ -1,0 +1,2 @@
+export type { AvatarCardProps } from "./avatar-card.js";
+export { AvatarCard } from "./avatar-card.js";

--- a/ui-next/packages/avatar/src/index.ts
+++ b/ui-next/packages/avatar/src/index.ts
@@ -4,3 +4,5 @@ export type { AvatarCardProps } from "./avatar-card/index.js";
 export { AvatarCard } from "./avatar-card/index.js";
 export type { PortraitProps } from "./portrait/index.js";
 export { Portrait } from "./portrait/index.js";
+export type { TeamDisplayProps } from "./team-display/index.js";
+export { TeamDisplay } from "./team-display/index.js";

--- a/ui-next/packages/avatar/src/index.ts
+++ b/ui-next/packages/avatar/src/index.ts
@@ -1,4 +1,6 @@
 // @gcsim/avatar public API
 
+export type { AvatarCardProps } from "./avatar-card/index.js";
+export { AvatarCard } from "./avatar-card/index.js";
 export type { PortraitProps } from "./portrait/index.js";
 export { Portrait } from "./portrait/index.js";

--- a/ui-next/packages/avatar/src/index.ts
+++ b/ui-next/packages/avatar/src/index.ts
@@ -1,1 +1,4 @@
 // @gcsim/avatar public API
+
+export type { PortraitProps } from "./portrait/index.js";
+export { Portrait } from "./portrait/index.js";

--- a/ui-next/packages/avatar/src/index.ts
+++ b/ui-next/packages/avatar/src/index.ts
@@ -1,0 +1,1 @@
+// @gcsim/avatar public API

--- a/ui-next/packages/avatar/src/portrait/index.ts
+++ b/ui-next/packages/avatar/src/portrait/index.ts
@@ -1,0 +1,2 @@
+export type { PortraitProps } from "./portrait.js";
+export { Portrait } from "./portrait.js";

--- a/ui-next/packages/avatar/src/portrait/portrait.test.tsx
+++ b/ui-next/packages/avatar/src/portrait/portrait.test.tsx
@@ -1,0 +1,60 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { Portrait } from "./portrait.js";
+
+describe("Portrait", () => {
+  it("renders with character key initial", () => {
+    render(<Portrait characterKey="hutao" />);
+    expect(screen.getByTestId("portrait-initial")).toHaveTextContent("H");
+  });
+
+  it("shows ? for empty character key", () => {
+    render(<Portrait characterKey="" />);
+    expect(screen.getByTestId("portrait-initial")).toHaveTextContent("?");
+  });
+
+  it("shows element indicator when element is provided", () => {
+    render(<Portrait characterKey="hutao" element="pyro" />);
+    const el = screen.getByTestId("portrait-element");
+    expect(el).toHaveTextContent("pyro");
+    expect(el.className).toContain("text-pyro");
+  });
+
+  it("does not show element indicator when element is not provided", () => {
+    render(<Portrait characterKey="hutao" />);
+    expect(screen.queryByTestId("portrait-element")).toBeNull();
+  });
+
+  it("applies sm size classes", () => {
+    render(<Portrait characterKey="hutao" size="sm" />);
+    const portrait = screen.getByTestId("portrait");
+    expect(portrait.className).toContain("h-8");
+    expect(portrait.className).toContain("w-8");
+  });
+
+  it("applies md size classes by default", () => {
+    render(<Portrait characterKey="hutao" />);
+    const portrait = screen.getByTestId("portrait");
+    expect(portrait.className).toContain("h-12");
+    expect(portrait.className).toContain("w-12");
+  });
+
+  it("applies lg size classes", () => {
+    render(<Portrait characterKey="hutao" size="lg" />);
+    const portrait = screen.getByTestId("portrait");
+    expect(portrait.className).toContain("h-16");
+    expect(portrait.className).toContain("w-16");
+  });
+
+  it("applies element border color", () => {
+    render(<Portrait characterKey="hutao" element="pyro" />);
+    const portrait = screen.getByTestId("portrait");
+    expect(portrait.className).toContain("border-pyro/40");
+  });
+
+  it("applies custom className", () => {
+    render(<Portrait characterKey="hutao" className="my-custom-class" />);
+    const portrait = screen.getByTestId("portrait");
+    expect(portrait.className).toContain("my-custom-class");
+  });
+});

--- a/ui-next/packages/avatar/src/portrait/portrait.tsx
+++ b/ui-next/packages/avatar/src/portrait/portrait.tsx
@@ -1,0 +1,65 @@
+import { cn } from "@gcsim/primitives";
+
+const sizeClasses = {
+  sm: "h-8 w-8 text-xs",
+  md: "h-12 w-12 text-sm",
+  lg: "h-16 w-16 text-lg",
+} as const;
+
+const elementColorClasses: Record<string, string> = {
+  anemo: "text-anemo",
+  geo: "text-geo",
+  electro: "text-electro",
+  hydro: "text-hydro",
+  pyro: "text-pyro",
+  cryo: "text-cryo",
+  dendro: "text-dendro",
+};
+
+const elementBgClasses: Record<string, string> = {
+  anemo: "border-anemo/40",
+  geo: "border-geo/40",
+  electro: "border-electro/40",
+  hydro: "border-hydro/40",
+  pyro: "border-pyro/40",
+  cryo: "border-cryo/40",
+  dendro: "border-dendro/40",
+};
+
+export interface PortraitProps {
+  characterKey: string;
+  element?: string;
+  size?: "sm" | "md" | "lg";
+  className?: string;
+}
+
+export function Portrait({ characterKey, element, size = "md", className }: PortraitProps) {
+  const initial = characterKey ? characterKey[0]?.toUpperCase() : "?";
+  const borderClass = element ? elementBgClasses[element] : "border-muted";
+  const elementColor = element ? elementColorClasses[element] : undefined;
+
+  return (
+    <div
+      data-testid="portrait"
+      className={cn(
+        "relative inline-flex items-center justify-center rounded-full border-2 bg-muted font-semibold",
+        sizeClasses[size],
+        borderClass,
+        className,
+      )}
+    >
+      <span data-testid="portrait-initial">{initial}</span>
+      {element ? (
+        <span
+          data-testid="portrait-element"
+          className={cn(
+            "absolute -bottom-1 -right-1 rounded-full bg-background px-1 text-[0.6em] font-bold leading-tight",
+            elementColor,
+          )}
+        >
+          {element}
+        </span>
+      ) : null}
+    </div>
+  );
+}

--- a/ui-next/packages/avatar/src/team-display/index.ts
+++ b/ui-next/packages/avatar/src/team-display/index.ts
@@ -1,0 +1,2 @@
+export type { TeamDisplayProps } from "./team-display.js";
+export { TeamDisplay } from "./team-display.js";

--- a/ui-next/packages/avatar/src/team-display/team-display.test.tsx
+++ b/ui-next/packages/avatar/src/team-display/team-display.test.tsx
@@ -1,0 +1,41 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { mockCharacters, mockHutao, mockXingqiu } from "../../../../tooling/test-fixtures/index.js";
+import { TeamDisplay } from "./team-display.js";
+
+describe("TeamDisplay", () => {
+  it("renders correct number of portraits for 2 characters", () => {
+    render(<TeamDisplay characters={mockCharacters} />);
+    const portraits = screen.getAllByTestId("portrait");
+    expect(portraits).toHaveLength(2);
+  });
+
+  it("handles empty team", () => {
+    render(<TeamDisplay characters={[]} />);
+    expect(screen.getByTestId("team-display")).toHaveTextContent("No characters");
+    expect(screen.queryAllByTestId("portrait")).toHaveLength(0);
+  });
+
+  it("handles 1 character", () => {
+    render(<TeamDisplay characters={[mockHutao]} />);
+    expect(screen.getAllByTestId("portrait")).toHaveLength(1);
+  });
+
+  it("handles 4 characters", () => {
+    const team = [mockHutao, mockXingqiu, mockHutao, mockXingqiu];
+    // Note: keys may collide with duplicate names, but this tests the count
+    render(<TeamDisplay characters={team} />);
+    expect(screen.getAllByTestId("portrait")).toHaveLength(4);
+  });
+
+  it("passes element to portraits", () => {
+    render(<TeamDisplay characters={[mockHutao]} />);
+    const element = screen.getByTestId("portrait-element");
+    expect(element).toHaveTextContent("pyro");
+  });
+
+  it("applies custom className", () => {
+    render(<TeamDisplay characters={[]} className="my-class" />);
+    expect(screen.getByTestId("team-display").className).toContain("my-class");
+  });
+});

--- a/ui-next/packages/avatar/src/team-display/team-display.tsx
+++ b/ui-next/packages/avatar/src/team-display/team-display.tsx
@@ -1,0 +1,26 @@
+import { cn } from "@gcsim/primitives";
+import type { Sim } from "@gcsim/types";
+import { Portrait } from "../portrait/index.js";
+
+export interface TeamDisplayProps {
+  characters: Sim.Character[];
+  className?: string;
+}
+
+export function TeamDisplay({ characters, className }: TeamDisplayProps) {
+  if (characters.length === 0) {
+    return (
+      <div data-testid="team-display" className={cn("flex items-center gap-2", className)}>
+        <span className="text-sm text-muted-foreground">No characters</span>
+      </div>
+    );
+  }
+
+  return (
+    <div data-testid="team-display" className={cn("flex items-center gap-2", className)}>
+      {characters.map((char) => (
+        <Portrait key={char.name} characterKey={char.name} element={char.element} size="md" />
+      ))}
+    </div>
+  );
+}

--- a/ui-next/packages/avatar/src/team-display/team-display.tsx
+++ b/ui-next/packages/avatar/src/team-display/team-display.tsx
@@ -18,8 +18,13 @@ export function TeamDisplay({ characters, className }: TeamDisplayProps) {
 
   return (
     <div data-testid="team-display" className={cn("flex items-center gap-2", className)}>
-      {characters.map((char) => (
-        <Portrait key={char.name} characterKey={char.name} element={char.element} size="md" />
+      {characters.map((char, index) => (
+        <Portrait
+          key={`${char.name}-${index}`}
+          characterKey={char.name}
+          element={char.element}
+          size="md"
+        />
       ))}
     </div>
   );

--- a/ui-next/packages/avatar/src/test-setup.ts
+++ b/ui-next/packages/avatar/src/test-setup.ts
@@ -1,0 +1,1 @@
+import "@testing-library/jest-dom/vitest";

--- a/ui-next/packages/avatar/tsconfig.json
+++ b/ui-next/packages/avatar/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tooling/typescript/base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"]
+}

--- a/ui-next/packages/avatar/tsconfig.json
+++ b/ui-next/packages/avatar/tsconfig.json
@@ -4,5 +4,6 @@
     "outDir": "dist",
     "rootDir": "src"
   },
-  "include": ["src"]
+  "include": ["src"],
+  "exclude": ["node_modules", "dist", "src/**/*.test.ts", "src/**/*.test.tsx"]
 }

--- a/ui-next/packages/avatar/vitest.config.ts
+++ b/ui-next/packages/avatar/vitest.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig, mergeConfig } from "vitest/config";
+import baseConfig from "../../tooling/vitest/base.ts";
+
+export default mergeConfig(
+  baseConfig,
+  defineConfig({
+    test: {
+      setupFiles: ["./src/test-setup.ts"],
+    },
+  }),
+);

--- a/ui-next/pnpm-lock.yaml
+++ b/ui-next/pnpm-lock.yaml
@@ -98,6 +98,46 @@ importers:
         specifier: 4.1.0
         version: 4.1.0(jsdom@29.0.0(@noble/hashes@1.8.0))(msw@2.12.13(typescript@5.9.3))(vite@8.0.1(esbuild@0.27.4)(jiti@2.6.1))
 
+  packages/avatar:
+    dependencies:
+      '@gcsim/data':
+        specifier: workspace:*
+        version: link:../data
+      '@gcsim/primitives':
+        specifier: workspace:*
+        version: link:../primitives
+      '@gcsim/types':
+        specifier: workspace:*
+        version: link:../types
+    devDependencies:
+      '@testing-library/jest-dom':
+        specifier: 6.6.3
+        version: 6.6.3
+      '@testing-library/react':
+        specifier: 16.3.0
+        version: 16.3.0(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@types/react':
+        specifier: ^19.0.0
+        version: 19.2.14
+      '@types/react-dom':
+        specifier: ^19.0.0
+        version: 19.2.3(@types/react@19.2.14)
+      jsdom:
+        specifier: 29.0.0
+        version: 29.0.0(@noble/hashes@1.8.0)
+      react:
+        specifier: 19.2.4
+        version: 19.2.4
+      react-dom:
+        specifier: 19.2.4
+        version: 19.2.4(react@19.2.4)
+      typescript:
+        specifier: 5.9.3
+        version: 5.9.3
+      vitest:
+        specifier: 4.1.0
+        version: 4.1.0(jsdom@29.0.0(@noble/hashes@1.8.0))(msw@2.12.13(typescript@5.9.3))(vite@8.0.1(esbuild@0.27.4)(jiti@2.6.1))
+
   packages/data:
     dependencies:
       '@gcsim/types':
@@ -225,6 +265,55 @@ importers:
       typescript:
         specifier: 5.9.3
         version: 5.9.3
+      vitest:
+        specifier: 4.1.0
+        version: 4.1.0(jsdom@29.0.0(@noble/hashes@1.8.0))(msw@2.12.13(typescript@5.9.3))(vite@8.0.1(esbuild@0.27.4)(jiti@2.6.1))
+
+  packages/viewer:
+    dependencies:
+      '@gcsim/i18n':
+        specifier: workspace:*
+        version: link:../i18n
+      '@gcsim/primitives':
+        specifier: workspace:*
+        version: link:../primitives
+      '@gcsim/types':
+        specifier: workspace:*
+        version: link:../types
+    devDependencies:
+      '@tailwindcss/vite':
+        specifier: 4.2.2
+        version: 4.2.2(vite@8.0.1(esbuild@0.27.4)(jiti@2.6.1))
+      '@testing-library/jest-dom':
+        specifier: 6.6.3
+        version: 6.6.3
+      '@testing-library/react':
+        specifier: 16.3.0
+        version: 16.3.0(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@types/react':
+        specifier: ^19.0.0
+        version: 19.2.14
+      '@types/react-dom':
+        specifier: ^19.0.0
+        version: 19.2.3(@types/react@19.2.14)
+      jsdom:
+        specifier: 29.0.0
+        version: 29.0.0(@noble/hashes@1.8.0)
+      react:
+        specifier: 19.2.4
+        version: 19.2.4
+      react-dom:
+        specifier: 19.2.4
+        version: 19.2.4(react@19.2.4)
+      tailwindcss:
+        specifier: 4.2.2
+        version: 4.2.2
+      typescript:
+        specifier: 5.9.3
+        version: 5.9.3
+      vite:
+        specifier: 8.0.1
+        version: 8.0.1(esbuild@0.27.4)(jiti@2.6.1)
       vitest:
         specifier: 4.1.0
         version: 4.1.0(jsdom@29.0.0(@noble/hashes@1.8.0))(msw@2.12.13(typescript@5.9.3))(vite@8.0.1(esbuild@0.27.4)(jiti@2.6.1))


### PR DESCRIPTION
## Summary
- Scaffold `@gcsim/avatar` package with portrait, avatar-card, and team-display components
- Portrait: circular avatar with character initial + element color badge, 3 sizes
- AvatarCard: full character card with name, level, cons, weapon, talents
- TeamDisplay: horizontal row of 1-4 portraits
- 23 tests passing, typecheck clean, build succeeds

## Test plan
- [x] `turbo run typecheck --filter=@gcsim/avatar` passes
- [x] `turbo run test --filter=@gcsim/avatar` passes (23 tests)
- [x] `turbo run build --filter=@gcsim/avatar` succeeds
- [x] Biome check clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)