### PR TITLE
Phase 3: Add Storybook stories for avatar and viewer components

### DIFF
--- a/ui-next/CLAUDE.md
+++ b/ui-next/CLAUDE.md
@@ -87,6 +87,19 @@ Every implementation step follows: write failing test → implement → pass tes
 | Feature packages | Component behavior with mocked data | Internal implementation |
 | Apps (unit) | Store logic, data transforms, hooks | Component rendering |
 
+## Storybook
+
+Every new React component (primitives or feature packages) **must** have a Storybook story in `apps/storybook/src/stories/`. This is how components are visually reviewed.
+
+When adding a story:
+1. Create `apps/storybook/src/stories/<component>.stories.tsx`
+2. If the component's package isn't already a storybook dependency, add it to `apps/storybook/package.json` and add a `@source` directive in `apps/storybook/src/storybook.css` for Tailwind class scanning
+3. Include stories for all key variants/states (default, edge cases, compositions)
+4. Use realistic mock data (reference `tooling/test-fixtures/` or inline)
+5. Verify: `turbo run build --filter=@gcsim/storybook` succeeds
+
+Dev server: `pnpm --filter @gcsim/storybook dev` (port 6006)
+
 ## Environment Variables
 
 Apps use `import.meta.env.VITE_*`. See `.env.example` for available variables:

--- a/ui-next/apps/storybook/package.json
+++ b/ui-next/apps/storybook/package.json
@@ -9,7 +9,10 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@gcsim/primitives": "workspace:*"
+    "@gcsim/avatar": "workspace:*",
+    "@gcsim/primitives": "workspace:*",
+    "@gcsim/types": "workspace:*",
+    "@gcsim/viewer": "workspace:*"
   },
   "devDependencies": {
     "@storybook/react": "10.3.1",

--- a/ui-next/apps/storybook/src/stories/avatar-card.stories.tsx
+++ b/ui-next/apps/storybook/src/stories/avatar-card.stories.tsx
@@ -1,0 +1,56 @@
+import { AvatarCard } from "@gcsim/avatar";
+import type { Sim } from "@gcsim/types";
+import type { Meta, StoryObj } from "@storybook/react";
+
+const hutao: Sim.Character = {
+  name: "hutao",
+  level: 90,
+  element: "pyro",
+  max_level: 90,
+  cons: 1,
+  weapon: { name: "staffofhoma", refine: 1, level: 90, max_level: 90 },
+  talents: { attack: 10, skill: 10, burst: 10 },
+  stats: [],
+  snapshot: [],
+  sets: { crimsonwitchofflames: 4 },
+};
+
+const xingqiu: Sim.Character = {
+  name: "xingqiu",
+  level: 90,
+  element: "hydro",
+  max_level: 90,
+  cons: 6,
+  weapon: { name: "sacrificialsword", refine: 5, level: 90, max_level: 90 },
+  talents: { attack: 1, skill: 10, burst: 13 },
+  stats: [],
+  snapshot: [],
+  sets: { emblemofseveredfate: 4 },
+};
+
+const meta = {
+  title: "Avatar/AvatarCard",
+  component: AvatarCard,
+  tags: ["autodocs"],
+} satisfies Meta<typeof AvatarCard>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Hutao: Story = {
+  args: { character: hutao },
+};
+
+export const Xingqiu: Story = {
+  args: { character: xingqiu },
+};
+
+export const SideBySide: Story = {
+  args: { character: hutao },
+  render: () => (
+    <div className="flex gap-4">
+      <AvatarCard character={hutao} />
+      <AvatarCard character={xingqiu} />
+    </div>
+  ),
+};

--- a/ui-next/apps/storybook/src/stories/badge.stories.tsx
+++ b/ui-next/apps/storybook/src/stories/badge.stories.tsx
@@ -1,5 +1,5 @@
-import type { Meta, StoryObj } from "@storybook/react";
 import { Badge } from "@gcsim/primitives";
+import type { Meta, StoryObj } from "@storybook/react";
 
 const meta = {
   title: "Primitives/Badge",

--- a/ui-next/apps/storybook/src/stories/button.stories.tsx
+++ b/ui-next/apps/storybook/src/stories/button.stories.tsx
@@ -1,5 +1,5 @@
-import type { Meta, StoryObj } from "@storybook/react";
 import { Button } from "@gcsim/primitives";
+import type { Meta, StoryObj } from "@storybook/react";
 
 const meta = {
   title: "Primitives/Button",

--- a/ui-next/apps/storybook/src/stories/card.stories.tsx
+++ b/ui-next/apps/storybook/src/stories/card.stories.tsx
@@ -1,4 +1,3 @@
-import type { Meta, StoryObj } from "@storybook/react";
 import {
   Button,
   Card,
@@ -8,6 +7,7 @@ import {
   CardHeader,
   CardTitle,
 } from "@gcsim/primitives";
+import type { Meta, StoryObj } from "@storybook/react";
 
 const meta = {
   title: "Primitives/Card",

--- a/ui-next/apps/storybook/src/stories/dialog.stories.tsx
+++ b/ui-next/apps/storybook/src/stories/dialog.stories.tsx
@@ -1,4 +1,3 @@
-import type { Meta, StoryObj } from "@storybook/react";
 import {
   Button,
   Dialog,
@@ -10,6 +9,7 @@ import {
   DialogTrigger,
   Input,
 } from "@gcsim/primitives";
+import type { Meta, StoryObj } from "@storybook/react";
 
 const meta = {
   title: "Primitives/Dialog",

--- a/ui-next/apps/storybook/src/stories/dps-card.stories.tsx
+++ b/ui-next/apps/storybook/src/stories/dps-card.stories.tsx
@@ -1,0 +1,65 @@
+import { DPSCard } from "@gcsim/viewer";
+import type { Meta, StoryObj } from "@storybook/react";
+
+const meta = {
+  title: "Viewer/DPSCard",
+  component: DPSCard,
+  tags: ["autodocs"],
+} satisfies Meta<typeof DPSCard>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    characterName: "hutao",
+    stat: { min: 20000, max: 45000, mean: 35100, sd: 3200 },
+    maxDPS: 35100,
+  },
+};
+
+export const PartialBar: Story = {
+  args: {
+    characterName: "xingqiu",
+    stat: { min: 10000, max: 25000, mean: 15150, sd: 2100 },
+    maxDPS: 35100,
+  },
+};
+
+export const NoData: Story = {
+  args: {
+    characterName: "unknown",
+    stat: undefined,
+  },
+};
+
+export const MultipleCharacters: Story = {
+  args: { characterName: "hutao" },
+  render: () => {
+    const maxDPS = 35100;
+    return (
+      <div className="flex flex-col gap-2 w-[400px]">
+        <DPSCard
+          characterName="hutao"
+          stat={{ min: 20000, max: 45000, mean: 35100, sd: 3200 }}
+          maxDPS={maxDPS}
+        />
+        <DPSCard
+          characterName="xingqiu"
+          stat={{ min: 10000, max: 25000, mean: 15150, sd: 2100 }}
+          maxDPS={maxDPS}
+        />
+        <DPSCard
+          characterName="zhongli"
+          stat={{ min: 500, max: 3000, mean: 1200, sd: 400 }}
+          maxDPS={maxDPS}
+        />
+        <DPSCard
+          characterName="kazuha"
+          stat={{ min: 2000, max: 8000, mean: 4500, sd: 1100 }}
+          maxDPS={maxDPS}
+        />
+      </div>
+    );
+  },
+};

--- a/ui-next/apps/storybook/src/stories/dropdown-menu.stories.tsx
+++ b/ui-next/apps/storybook/src/stories/dropdown-menu.stories.tsx
@@ -1,4 +1,3 @@
-import type { Meta, StoryObj } from "@storybook/react";
 import {
   Button,
   DropdownMenu,
@@ -8,6 +7,7 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@gcsim/primitives";
+import type { Meta, StoryObj } from "@storybook/react";
 
 const meta = {
   title: "Primitives/DropdownMenu",

--- a/ui-next/apps/storybook/src/stories/input.stories.tsx
+++ b/ui-next/apps/storybook/src/stories/input.stories.tsx
@@ -1,5 +1,5 @@
-import type { Meta, StoryObj } from "@storybook/react";
 import { Input } from "@gcsim/primitives";
+import type { Meta, StoryObj } from "@storybook/react";
 
 const meta = {
   title: "Primitives/Input",

--- a/ui-next/apps/storybook/src/stories/metadata.stories.tsx
+++ b/ui-next/apps/storybook/src/stories/metadata.stories.tsx
@@ -1,0 +1,95 @@
+import { Commit, Iterations, Mode, Warnings } from "@gcsim/viewer";
+import type { Meta, StoryObj } from "@storybook/react";
+
+export default {
+  title: "Viewer/Metadata",
+  tags: ["autodocs"],
+} satisfies Meta;
+
+export const IterationsStory: StoryObj = {
+  name: "Iterations",
+  render: () => <Iterations iterations={1000} />,
+};
+
+export const IterationsLarge: StoryObj = {
+  name: "Iterations (large number)",
+  render: () => <Iterations iterations={100000} />,
+};
+
+export const ModeSL: StoryObj = {
+  name: "Mode: SL",
+  render: () => <Mode mode={0} />,
+};
+
+export const ModeTTK: StoryObj = {
+  name: "Mode: TTK",
+  render: () => <Mode mode={1} />,
+};
+
+export const CommitInfo: StoryObj = {
+  name: "Commit",
+  render: () => <Commit simVersion="2.5.0" buildDate="2026-03-19" />,
+};
+
+export const CommitVersionOnly: StoryObj = {
+  name: "Commit (version only)",
+  render: () => <Commit simVersion="2.5.0" />,
+};
+
+export const NoWarnings: StoryObj = {
+  name: "Warnings (none active)",
+  render: () => (
+    <Warnings
+      warnings={{
+        target_overlap: false,
+        insufficient_energy: false,
+        insufficient_stamina: false,
+        swap_cd: false,
+        skill_cd: false,
+        dash_cd: false,
+        burst_cd: false,
+      }}
+    />
+  ),
+};
+
+export const ActiveWarnings: StoryObj = {
+  name: "Warnings (active)",
+  render: () => (
+    <Warnings
+      warnings={{
+        target_overlap: false,
+        insufficient_energy: true,
+        insufficient_stamina: false,
+        swap_cd: true,
+        skill_cd: false,
+        dash_cd: false,
+        burst_cd: true,
+      }}
+    />
+  ),
+};
+
+export const AllTogether: StoryObj = {
+  name: "All metadata together",
+  render: () => (
+    <div className="flex flex-col gap-3">
+      <div className="flex items-center gap-4 text-sm">
+        <Iterations iterations={1000} />
+        <Mode mode={0} />
+        <Commit simVersion="2.5.0" buildDate="2026-03-19" />
+      </div>
+      <Warnings
+        warnings={{
+          target_overlap: false,
+          insufficient_energy: true,
+          insufficient_stamina: false,
+          swap_cd: false,
+          skill_cd: false,
+          dash_cd: false,
+          burst_cd: false,
+        }}
+      />
+    </div>
+  ),
+};

--- a/ui-next/apps/storybook/src/stories/portrait.stories.tsx
+++ b/ui-next/apps/storybook/src/stories/portrait.stories.tsx
@@ -1,0 +1,63 @@
+import { Portrait } from "@gcsim/avatar";
+import type { Meta, StoryObj } from "@storybook/react";
+
+const meta = {
+  title: "Avatar/Portrait",
+  component: Portrait,
+  tags: ["autodocs"],
+  argTypes: {
+    size: {
+      control: "select",
+      options: ["sm", "md", "lg"],
+    },
+    element: {
+      control: "select",
+      options: ["pyro", "hydro", "electro", "cryo", "anemo", "geo", "dendro"],
+    },
+  },
+} satisfies Meta<typeof Portrait>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: { characterKey: "hutao", element: "pyro", size: "md" },
+};
+
+export const Small: Story = {
+  args: { characterKey: "xingqiu", element: "hydro", size: "sm" },
+};
+
+export const Large: Story = {
+  args: { characterKey: "raiden", element: "electro", size: "lg" },
+};
+
+export const NoElement: Story = {
+  args: { characterKey: "unknown" },
+};
+
+export const AllElements: Story = {
+  args: { characterKey: "hutao" },
+  render: () => (
+    <div className="flex items-center gap-4">
+      <Portrait characterKey="hutao" element="pyro" size="lg" />
+      <Portrait characterKey="xingqiu" element="hydro" size="lg" />
+      <Portrait characterKey="raiden" element="electro" size="lg" />
+      <Portrait characterKey="ganyu" element="cryo" size="lg" />
+      <Portrait characterKey="kazuha" element="anemo" size="lg" />
+      <Portrait characterKey="zhongli" element="geo" size="lg" />
+      <Portrait characterKey="nahida" element="dendro" size="lg" />
+    </div>
+  ),
+};
+
+export const AllSizes: Story = {
+  args: { characterKey: "hutao" },
+  render: () => (
+    <div className="flex items-end gap-4">
+      <Portrait characterKey="hutao" element="pyro" size="sm" />
+      <Portrait characterKey="hutao" element="pyro" size="md" />
+      <Portrait characterKey="hutao" element="pyro" size="lg" />
+    </div>
+  ),
+};

--- a/ui-next/apps/storybook/src/stories/rollup-card.stories.tsx
+++ b/ui-next/apps/storybook/src/stories/rollup-card.stories.tsx
@@ -1,0 +1,50 @@
+import { RollupCard } from "@gcsim/viewer";
+import type { Meta, StoryObj } from "@storybook/react";
+
+const meta = {
+  title: "Viewer/RollupCard",
+  component: RollupCard,
+  tags: ["autodocs"],
+} satisfies Meta<typeof RollupCard>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const DPS: Story = {
+  args: {
+    label: "DPS",
+    stat: { min: 35000, max: 65000, mean: 50250.5, sd: 4200.3 },
+  },
+};
+
+export const Duration: Story = {
+  args: {
+    label: "Duration (frames)",
+    stat: { min: 85, max: 105, mean: 95.2, sd: 3.1 },
+  },
+};
+
+export const NoData: Story = {
+  args: {
+    label: "No Data",
+    stat: undefined,
+  },
+};
+
+export const ZeroValues: Story = {
+  args: {
+    label: "Zero Stats",
+    stat: { min: 0, max: 0, mean: 0, sd: 0 },
+  },
+};
+
+export const MultipleCards: Story = {
+  args: { label: "DPS" },
+  render: () => (
+    <div className="flex flex-wrap gap-3">
+      <RollupCard label="DPS" stat={{ min: 35000, max: 65000, mean: 50250, sd: 4200 }} />
+      <RollupCard label="Duration" stat={{ min: 85, max: 105, mean: 95.2, sd: 3.1 }} />
+      <RollupCard label="EPS" stat={{ min: 1.2, max: 3.5, mean: 2.1, sd: 0.4 }} />
+    </div>
+  ),
+};

--- a/ui-next/apps/storybook/src/stories/scroll-area.stories.tsx
+++ b/ui-next/apps/storybook/src/stories/scroll-area.stories.tsx
@@ -1,5 +1,5 @@
-import type { Meta, StoryObj } from "@storybook/react";
 import { ScrollArea } from "@gcsim/primitives";
+import type { Meta, StoryObj } from "@storybook/react";
 
 const meta = {
   title: "Primitives/ScrollArea",

--- a/ui-next/apps/storybook/src/stories/select.stories.tsx
+++ b/ui-next/apps/storybook/src/stories/select.stories.tsx
@@ -1,4 +1,3 @@
-import type { Meta, StoryObj } from "@storybook/react";
 import {
   Select,
   SelectContent,
@@ -8,6 +7,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@gcsim/primitives";
+import type { Meta, StoryObj } from "@storybook/react";
 
 const meta = {
   title: "Primitives/Select",

--- a/ui-next/apps/storybook/src/stories/skeleton.stories.tsx
+++ b/ui-next/apps/storybook/src/stories/skeleton.stories.tsx
@@ -1,5 +1,5 @@
-import type { Meta, StoryObj } from "@storybook/react";
 import { Skeleton } from "@gcsim/primitives";
+import type { Meta, StoryObj } from "@storybook/react";
 
 const meta = {
   title: "Primitives/Skeleton",

--- a/ui-next/apps/storybook/src/stories/tabs.stories.tsx
+++ b/ui-next/apps/storybook/src/stories/tabs.stories.tsx
@@ -1,5 +1,5 @@
-import type { Meta, StoryObj } from "@storybook/react";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@gcsim/primitives";
+import type { Meta, StoryObj } from "@storybook/react";
 
 const meta = {
   title: "Primitives/Tabs",

--- a/ui-next/apps/storybook/src/stories/target-info-card.stories.tsx
+++ b/ui-next/apps/storybook/src/stories/target-info-card.stories.tsx
@@ -1,0 +1,94 @@
+import type { Sim } from "@gcsim/types";
+import { TargetInfoCard } from "@gcsim/viewer";
+import type { Meta, StoryObj } from "@storybook/react";
+
+const singleTarget: Sim.Enemy[] = [
+  {
+    name: "target-1",
+    level: 100,
+    hp: 10000000,
+    resist: {
+      pyro: 0.1,
+      hydro: 0.1,
+      electro: 0.1,
+      cryo: 0.1,
+      anemo: 0.1,
+      geo: 0.1,
+      dendro: 0.1,
+      physical: 0.1,
+    },
+    position: { x: 0, y: 0, r: 1 },
+  },
+];
+
+const multipleTargets: Sim.Enemy[] = [
+  {
+    name: "boss",
+    level: 100,
+    hp: 20000000,
+    resist: {
+      pyro: 0.7,
+      hydro: 0.1,
+      electro: 0.1,
+      cryo: 0.1,
+      anemo: 0.1,
+      geo: 0.1,
+      dendro: 0.1,
+      physical: 0.3,
+    },
+    position: { x: 0, y: 0, r: 2 },
+  },
+  {
+    name: "add-1",
+    level: 90,
+    hp: 500000,
+    resist: {
+      pyro: 0.1,
+      hydro: 0.1,
+      electro: 0.1,
+      cryo: 0.1,
+      anemo: 0.1,
+      geo: 0.1,
+      dendro: 0.1,
+      physical: 0.1,
+    },
+    position: { x: 3, y: 0, r: 1 },
+  },
+  {
+    name: "add-2",
+    level: 90,
+    hp: 500000,
+    resist: {
+      pyro: 0.1,
+      hydro: 0.1,
+      electro: 0.1,
+      cryo: 0.1,
+      anemo: 0.1,
+      geo: 0.1,
+      dendro: 0.1,
+      physical: 0.1,
+    },
+    position: { x: -3, y: 0, r: 1 },
+  },
+];
+
+const meta = {
+  title: "Viewer/TargetInfoCard",
+  component: TargetInfoCard,
+  tags: ["autodocs"],
+} satisfies Meta<typeof TargetInfoCard>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const SingleTarget: Story = {
+  args: { enemies: singleTarget },
+};
+
+export const MultipleTargets: Story = {
+  args: { enemies: multipleTargets },
+};
+
+export const Empty: Story = {
+  args: { enemies: [] },
+};

--- a/ui-next/apps/storybook/src/stories/team-display.stories.tsx
+++ b/ui-next/apps/storybook/src/stories/team-display.stories.tsx
@@ -1,0 +1,48 @@
+import { TeamDisplay } from "@gcsim/avatar";
+import type { Sim } from "@gcsim/types";
+import type { Meta, StoryObj } from "@storybook/react";
+
+const makeChar = (name: string, element: string, cons: number): Sim.Character => ({
+  name,
+  level: 90,
+  element,
+  max_level: 90,
+  cons,
+  weapon: { name: "weapon", refine: 1, level: 90, max_level: 90 },
+  talents: { attack: 10, skill: 10, burst: 10 },
+  stats: [],
+  snapshot: [],
+  sets: {},
+});
+
+const fullTeam = [
+  makeChar("hutao", "pyro", 1),
+  makeChar("xingqiu", "hydro", 6),
+  makeChar("zhongli", "geo", 0),
+  makeChar("kazuha", "anemo", 0),
+];
+
+const meta = {
+  title: "Avatar/TeamDisplay",
+  component: TeamDisplay,
+  tags: ["autodocs"],
+} satisfies Meta<typeof TeamDisplay>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const FullTeam: Story = {
+  args: { characters: fullTeam },
+};
+
+export const TwoCharacters: Story = {
+  args: { characters: fullTeam.slice(0, 2) },
+};
+
+export const SingleCharacter: Story = {
+  args: { characters: fullTeam.slice(0, 1) },
+};
+
+export const EmptyTeam: Story = {
+  args: { characters: [] },
+};

--- a/ui-next/apps/storybook/src/stories/team-header.stories.tsx
+++ b/ui-next/apps/storybook/src/stories/team-header.stories.tsx
@@ -1,0 +1,50 @@
+import type { Sim } from "@gcsim/types";
+import { TeamHeader } from "@gcsim/viewer";
+import type { Meta, StoryObj } from "@storybook/react";
+
+const makeChar = (
+  name: string,
+  element: string,
+  cons: number,
+  weaponName: string,
+  refine: number,
+): Sim.Character => ({
+  name,
+  level: 90,
+  element,
+  max_level: 90,
+  cons,
+  weapon: { name: weaponName, refine, level: 90, max_level: 90 },
+  talents: { attack: 10, skill: 10, burst: 10 },
+  stats: [],
+  snapshot: [],
+  sets: {},
+});
+
+const team = [
+  makeChar("hutao", "pyro", 1, "staffofhoma", 1),
+  makeChar("xingqiu", "hydro", 6, "sacrificialsword", 5),
+  makeChar("zhongli", "geo", 0, "blacktassel", 5),
+  makeChar("kazuha", "anemo", 0, "freedomsworn", 1),
+];
+
+const meta = {
+  title: "Viewer/TeamHeader",
+  component: TeamHeader,
+  tags: ["autodocs"],
+} satisfies Meta<typeof TeamHeader>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const FullTeam: Story = {
+  args: { characters: team },
+};
+
+export const TwoCharacters: Story = {
+  args: { characters: team.slice(0, 2) },
+};
+
+export const Empty: Story = {
+  args: { characters: [] },
+};

--- a/ui-next/apps/storybook/src/stories/tooltip.stories.tsx
+++ b/ui-next/apps/storybook/src/stories/tooltip.stories.tsx
@@ -1,4 +1,3 @@
-import type { Meta, StoryObj } from "@storybook/react";
 import {
   Button,
   Tooltip,
@@ -6,8 +5,9 @@ import {
   TooltipProvider,
   TooltipTrigger,
 } from "@gcsim/primitives";
+import type { Meta, StoryObj } from "@storybook/react";
 
-const meta = {
+const meta: Meta<typeof Tooltip> = {
   title: "Primitives/Tooltip",
   component: Tooltip,
   tags: ["autodocs"],
@@ -18,7 +18,7 @@ const meta = {
       </TooltipProvider>
     ),
   ],
-} satisfies Meta<typeof Tooltip>;
+};
 
 export default meta;
 type Story = StoryObj<typeof meta>;

--- a/ui-next/apps/storybook/src/storybook.css
+++ b/ui-next/apps/storybook/src/storybook.css
@@ -3,6 +3,8 @@
 @import "shadcn/tailwind.css";
 
 @source "../../../packages/primitives/src";
+@source "../../../packages/avatar/src";
+@source "../../../packages/viewer/src";
 @source "../stories";
 
 @custom-variant dark (&:is(.dark *));

--- a/ui-next/apps/storybook/tsconfig.json
+++ b/ui-next/apps/storybook/tsconfig.json
@@ -9,5 +9,10 @@
     }
   },
   "include": ["src", ".storybook"],
-  "references": [{ "path": "../../packages/primitives" }]
+  "references": [
+    { "path": "../../packages/primitives" },
+    { "path": "../../packages/types" },
+    { "path": "../../packages/avatar" },
+    { "path": "../../packages/viewer" }
+  ]
 }

--- a/ui-next/pnpm-lock.yaml
+++ b/ui-next/pnpm-lock.yaml
@@ -26,9 +26,18 @@ importers:
 
   apps/storybook:
     dependencies:
+      '@gcsim/avatar':
+        specifier: workspace:*
+        version: link:../../packages/avatar
       '@gcsim/primitives':
         specifier: workspace:*
         version: link:../../packages/primitives
+      '@gcsim/types':
+        specifier: workspace:*
+        version: link:../../packages/types
+      '@gcsim/viewer':
+        specifier: workspace:*
+        version: link:../../packages/viewer
     devDependencies:
       '@storybook/react':
         specifier: 10.3.1


### PR DESCRIPTION
## Summary
- Add 8 new story files for avatar and viewer components
- Avatar: Portrait (all elements, all sizes), AvatarCard, TeamDisplay
- Viewer: Metadata, TeamHeader, RollupCard, DPSCard, TargetInfoCard
- Wire @gcsim/avatar, @gcsim/viewer, @gcsim/types into storybook deps
- Add Tailwind @source directives for new package class scanning
- Fix pre-existing tooltip.stories.tsx type inference error

## Test plan
- [x] `turbo run typecheck --filter=@gcsim/storybook` passes
- [x] `turbo run build --filter=@gcsim/storybook` succeeds
- [x] All 30 existing stories + 8 new stories build correctly
- [ ] Run `pnpm --filter @gcsim/storybook dev` and visually review components

🤖 Generated with [Claude Code](https://claude.com/claude-code)